### PR TITLE
refined error messages for better UX

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -1,6 +1,7 @@
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import prisma from "../lib/prisma.js";
+import { Prisma } from "@prisma/client";
 
 const SALT_ROUNDS = parseInt(process.env.SALT_ROUNDS);
 
@@ -25,7 +26,19 @@ export const register = async (req, res) => {
 
     res.status(201).json({ message: "User created successfully" });
   } catch (err) {
-    console.log(err);
+    // console.log(err);
+    // res.status(500).json({ message: "Failed to create user!" });
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === "P2002") {
+        // P2002 is an error code for unique constraint violation
+        if (err.meta?.target?.includes("username")) {
+          return res.status(409).json({ message: "Looks like this username is already taken. Please choose a different one." });
+        }
+        if (err.meta?.target?.includes("email")) {
+          return res.status(409).json({ message: "Looks like this email is already registered. Please choose a different one." });
+        }
+      }
+    }
     res.status(500).json({ message: "Failed to create user!" });
   }
 };


### PR DESCRIPTION
If the username or email is already taken during registration, users now see clear and specific error messages explaining the reason for failure.